### PR TITLE
Add MLflow tracing integration for agent conversations

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,15 @@ DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/your_warehouse_id
 # Note: DATABRICKS_TOKEN is shared with workspace auth above
 
 # -----------------------------------------------------------------------------
+# MLflow Tracing (Required for observability)
+# -----------------------------------------------------------------------------
+# Traces are sent to Databricks MLflow. Use ONE of these:
+# MLFLOW_EXPERIMENT_NAME = path (creates experiment if doesn't exist)
+# MLFLOW_EXPERIMENT_ID = numeric ID (experiment must already exist)
+MLFLOW_EXPERIMENT_NAME=/Users/your-email@company.com/personal-finance-traces
+# MLFLOW_EXPERIMENT_ID=123456789
+
+# -----------------------------------------------------------------------------
 # Lakebase PostgreSQL (Optional - for chat/profile persistence)
 # -----------------------------------------------------------------------------
 # Choose ONE of these three connection methods:
@@ -50,7 +59,7 @@ DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/your_warehouse_id
 # External APIs (Optional)
 # -----------------------------------------------------------------------------
 # News API for financial news feed (https://newsapi.org)
-# NEWSAPI_KEY=your_newsapi_key
+NEWSAPI_KEY=your_newsapi_key
 
 # -----------------------------------------------------------------------------
 # Databricks Apps Deployment (Required for ./scripts/deploy.sh)
@@ -61,4 +70,4 @@ WORKSPACE_SOURCE_PATH=/Workspace/Users/your-email@company.com/your-app-name
 # -----------------------------------------------------------------------------
 # App Configuration (Optional)
 # -----------------------------------------------------------------------------
-# ENV=development  # Auto-detected based on .env.local presence
+ENV=development  # Auto-detected based on .env.local presence

--- a/server/tracing.py
+++ b/server/tracing.py
@@ -1,7 +1,44 @@
-"""Minimal MLflow configuration for feedback logging."""
+"""MLflow tracing configuration for GenAI observability.
+
+This module configures MLflow to:
+1. Send traces to Databricks (not local MLflow)
+2. Set the experiment from MLFLOW_EXPERIMENT_ID env var
+3. Enable OpenAI autolog for automatic LLM call tracing
+"""
+
+import logging
+import os
 
 import mlflow
 
-# Set the MLflow tracking URI to Databricks
-# This is needed for mlflow.log_feedback() to work properly
+logger = logging.getLogger(__name__)
+
+# Configure MLflow to use Databricks as backend
+mlflow.set_registry_uri('databricks-uc')
 mlflow.set_tracking_uri('databricks')
+
+# Configure experiment from environment variable
+# MLFLOW_EXPERIMENT_NAME = path like /Users/.../name (creates if doesn't exist)
+# MLFLOW_EXPERIMENT_ID = numeric ID (must already exist)
+experiment_name = os.environ.get('MLFLOW_EXPERIMENT_NAME')
+experiment_id = os.environ.get('MLFLOW_EXPERIMENT_ID')
+
+if experiment_name:
+  # Use experiment name (path) - will create if doesn't exist
+  mlflow.set_experiment(experiment_name=experiment_name)
+  logger.info(f'MLflow experiment name: {experiment_name}')
+elif experiment_id:
+  # Use numeric experiment ID - must already exist
+  mlflow.set_experiment(experiment_id=experiment_id)
+  logger.info(f'MLflow experiment ID: {experiment_id}')
+else:
+  logger.warning(
+    'Neither MLFLOW_EXPERIMENT_NAME nor MLFLOW_EXPERIMENT_ID set - '
+    'traces will go to default experiment'
+  )
+
+# Note: OpenAI autolog is disabled because it creates separate root traces
+# that override our manual span's inputs/outputs, causing Request/Response
+# columns to show as null in the MLflow UI.
+# mlflow.openai.autolog()
+logger.info('MLflow tracing configured (autolog disabled for manual control)')


### PR DESCRIPTION
## Summary
- Configure MLflow to send traces to Databricks with experiment support via `MLFLOW_EXPERIMENT_NAME` or `MLFLOW_EXPERIMENT_ID` environment variables
- Add manual tracing spans in fmapi_handler for agent operations and tool executions
- Add session metadata (`mlflow.trace.session`, `mlflow.trace.user`) to group traces by chat conversation
- Set span inputs/outputs to populate Request/Response columns in MLflow UI
- Disable OpenAI autolog to maintain control over trace structure
- Update .env.template with MLflow configuration documentation

## Test plan
- [x] Verify traces appear in Databricks MLflow experiment
- [x] Confirm traces are grouped by session (chat_id)
- [x] Check Request/Response columns show user message and assistant response
- [x] Verify tool execution spans appear nested under handler span

🤖 Generated with [Claude Code](https://claude.com/claude-code)