### PR TITLE
Move tool call status inline and add dashboard improvements

### DIFF
--- a/client/src/components/chat/ChatCore.tsx
+++ b/client/src/components/chat/ChatCore.tsx
@@ -5,7 +5,6 @@ import { MessageList } from "./MessageList";
 import { ChatInput } from "./ChatInput";
 import { FeedbackModal } from "@/components/modals/FeedbackModal";
 import { TraceModal } from "@/components/modals/TraceModal";
-import { FunctionCallNotification } from "@/components/notifications/FunctionCallNotification";
 import { Message } from "@/lib/types";
 import { useUserInfo } from "@/hooks/useUserInfo";
 import { useAgents } from "@/hooks/useAgents";
@@ -541,6 +540,7 @@ export function ChatCore({
         <MessageList
           messages={messages}
           isLoading={isLoading}
+          activeFunctionCalls={activeFunctionCalls}
           onFeedback={handleFeedback}
           onViewTrace={handleTrace}
           selectedAgentId={selectedAgentId}
@@ -587,15 +587,6 @@ export function ChatCore({
         mlflowTraceUrl={getMlflowTraceUrl(traceModal.traceId)}
       />
 
-      {!compact && (
-        <FunctionCallNotification
-          functionCalls={activeFunctionCalls}
-          onDismiss={() => setActiveFunctionCalls([])}
-          autoHideDuration={5000}
-          isProcessing={isLoading}
-          agentName={selectedAgentId}
-        />
-      )}
     </div>
   );
 }

--- a/client/src/components/chat/MessageList.tsx
+++ b/client/src/components/chat/MessageList.tsx
@@ -1,13 +1,14 @@
 
 import React from "react";
 import { Message } from "./Message";
-import { Message as MessageType } from "@/lib/types";
-import { Loader2 } from "lucide-react";
+import { Message as MessageType, FunctionCall } from "@/lib/types";
 import { useAgents } from "@/hooks/useAgents";
+import { ToolCallStatus } from "./ToolCallStatus";
 
 interface MessageListProps {
   messages: MessageType[];
   isLoading: boolean;
+  activeFunctionCalls?: FunctionCall[];
   onFeedback: (messageId: string, type: "positive" | "negative") => void;
   onViewTrace: (messageId: string) => void;
   selectedAgentId?: string;
@@ -17,6 +18,7 @@ interface MessageListProps {
 export function MessageList({
   messages,
   isLoading,
+  activeFunctionCalls,
   onFeedback,
   onViewTrace,
   selectedAgentId,
@@ -54,10 +56,10 @@ export function MessageList({
       ))}
 
       {isLoading && (
-        <div className="flex items-center gap-3 text-[var(--color-muted-foreground)]">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm">AI is thinking...</span>
-        </div>
+        <ToolCallStatus
+          functionCalls={activeFunctionCalls || []}
+          isProcessing={isLoading}
+        />
       )}
     </div>
   );

--- a/client/src/components/chat/ToolCallStatus.tsx
+++ b/client/src/components/chat/ToolCallStatus.tsx
@@ -1,0 +1,65 @@
+import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { FunctionCall } from "@/lib/types";
+
+interface ToolCallStatusProps {
+  functionCalls: FunctionCall[];
+  isProcessing: boolean;
+}
+
+export function ToolCallStatus({
+  functionCalls,
+  isProcessing,
+}: ToolCallStatusProps) {
+  const isThinking = isProcessing && functionCalls.length === 0;
+  const allToolsComplete = functionCalls.length > 0 &&
+    functionCalls.every((fc) => fc.status === "completed" || fc.status === "error");
+  const isFormulatingResponse = isProcessing && allToolsComplete;
+
+  if (!isProcessing && functionCalls.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 text-[var(--color-muted-foreground)]">
+      {isThinking && (
+        <div className="flex items-center gap-3">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">AI is thinking...</span>
+        </div>
+      )}
+
+      {functionCalls.map((fc, idx) => (
+        <div
+          key={fc.call_id || idx}
+          className="flex items-center gap-3 animate-in fade-in duration-200"
+        >
+          {fc.status === "calling" && (
+            <Loader2 className="h-4 w-4 animate-spin text-[var(--color-primary)]" />
+          )}
+          {fc.status === "completed" && (
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+          )}
+          {fc.status === "error" && (
+            <XCircle className="h-4 w-4 text-red-500" />
+          )}
+          <span className="text-sm">{formatFunctionName(fc.name)}</span>
+        </div>
+      ))}
+
+      {isFormulatingResponse && (
+        <div className="flex items-center gap-3 mt-1 animate-in fade-in duration-200">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Formulating response...</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatFunctionName(name: string): string {
+  // Remove UUID-like suffixes
+  const cleanName = name.replace(/_[a-f0-9]{32}$/i, "");
+  // Convert snake_case to Title Case
+  return cleanName
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/client/src/components/finance/FinanceDashboard.tsx
+++ b/client/src/components/finance/FinanceDashboard.tsx
@@ -12,6 +12,7 @@ import {
   User,
   Target,
   Shield,
+  Clock,
 } from 'lucide-react';
 import { BentoCard, BentoCardHeader, BentoCardValue } from './BentoCard';
 import { FinancialNews } from './FinancialNews';
@@ -108,6 +109,7 @@ export function FinanceDashboard() {
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-6">
           <BentoSkeleton className="lg:col-span-2 lg:row-span-2" />
+          <BentoSkeleton />
           <BentoSkeleton />
           <BentoSkeleton />
           <BentoSkeleton />
@@ -338,7 +340,10 @@ export function FinanceDashboard() {
               </div>
               {profileData.investmentExperienceYears !== undefined && (
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-[var(--color-text-muted)]">Experience</span>
+                  <div className="flex items-center gap-2">
+                    <Clock className="w-4 h-4 text-[var(--color-text-muted)]" />
+                    <span className="text-sm text-[var(--color-text-muted)]">Experience</span>
+                  </div>
                   <span className="text-sm font-medium text-[var(--color-text-primary)]">
                     {profileData.investmentExperienceYears} years
                   </span>

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -1,0 +1,206 @@
+// Type definitions for the application
+
+// Stream event types from Databricks agent
+export interface StreamTextDelta {
+  type: "response.output_text.delta";
+  item_id: string;
+  delta: string;
+  id: string;
+}
+
+export interface StreamFunctionCall {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface StreamFunctionCallOutput {
+  type: "function_call_output";
+  call_id: string;
+  output: string;
+}
+
+export interface StreamMessageDone {
+  type: "response.output_item.done";
+  item: {
+    id: string;
+    type: "message" | "function_call" | "function_call_output";
+    content?: Array<{ text: string; type: "output_text" }>;
+    role?: string;
+    call_id?: string;
+    name?: string;
+    arguments?: string;
+    output?: string;
+  };
+  id: string;
+}
+
+export interface FunctionCall {
+  call_id: string;
+  name: string;
+  arguments?: any;
+  output?: any;
+  status?: "calling" | "completed" | "error";
+}
+
+export interface MASHandoff {
+  specialist: string;
+  request: any;
+  response?: any;
+  message_count: number;
+  messages: string[];
+}
+
+export interface MASFlow {
+  supervisor: string;
+  total_handoffs: number;
+  handoffs: MASHandoff[];
+}
+
+export interface TraceSummary {
+  trace_id: string;
+  duration_ms: number;
+  status: string;
+  deployment_type?: string; // Added to detect handler type
+  tools_called: Array<{
+    name: string;
+    duration_ms: number;
+    inputs?: any;
+    outputs?: any;
+    status: string;
+  }>;
+  retrieval_calls: Array<{
+    name: string;
+    duration_ms: number;
+    num_documents?: number;
+    relevance_scores?: number[];
+  }>;
+  llm_calls: Array<{
+    name: string;
+    duration_ms: number;
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+  }>;
+  total_tokens: number;
+  spans_count: number;
+  function_calls?: Array<{
+    call_id: string;
+    name: string;
+    arguments: any;
+    output?: any;
+  }>;
+  mas_flow?: MASFlow; // MAS-specific hierarchical structure
+}
+
+export interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+  traceId?: string;
+  visualizations?: Visualization[];
+  traceSummary?: TraceSummary;
+}
+
+export interface Visualization {
+  type: "line" | "bar" | "pie" | "table";
+  data: ChartData | TableData;
+  options?: any;
+}
+
+export interface ChartData {
+  labels: string[];
+  datasets: Dataset[];
+}
+
+export interface Dataset {
+  label: string;
+  data: number[];
+  borderColor?: string;
+  backgroundColor?: string;
+  tension?: number;
+}
+
+export interface TableData {
+  headers: string[];
+  rows: (string | number)[][];
+}
+
+export interface Chat {
+  id: string;
+  title: string;
+  agentId?: string; // Agent used for this chat (locked once set)
+  messages: Message[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface VolumeInfo {
+  name: string;
+  path: string;
+  indexed_rows?: number;
+  state?: string;
+}
+
+export interface Tool {
+  display_name: string;
+  description?: string;
+  display_description?: string;
+  long_description?: string;
+  type?: string; // "genie-space", "serving-endpoint", "app", "ka"
+  url?: string;
+  learn_more?: string;
+  // MAS sub-tool identifiers
+  genie_space_id?: string;
+  serving_endpoint_name?: string;
+  app_name?: string;
+  // Enriched data from APIs
+  volumes?: VolumeInfo[]; // KA volume paths
+  tables?: string[]; // Genie table identifiers
+  genie_display_name?: string;
+  ka_display_name?: string;
+  warehouse_id?: string;
+}
+
+export interface Agent {
+  id: string;
+  name: string;
+  endpoint_name: string;
+  tile_id?: string;
+  display_name: string;
+  display_description: string;
+  instructions?: string;
+  status?: string; // "ONLINE", "OFFLINE", "PROVISIONING", "NOT_READY"
+  chat_title?: string;
+  chat_subtitle?: string;
+  endpoint_url?: string;
+  llm?: string;
+  tools: Tool[];
+  deployment_type?: string;
+  mlflow_experiment_id?: string;
+  mlflow_experiment_url?: string;
+  mlflow_traces_url?: string;
+  error?: string; // If agent failed to load
+}
+
+export interface AgentMetadata {
+  agents: Agent[];
+}
+
+export interface Persona {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface TraceSpan {
+  name: string;
+  duration: number;
+  input: any;
+  output: any;
+  type: "llm" | "tool" | "retrieval" | "other";
+  children?: TraceSpan[];
+}


### PR DESCRIPTION
## Summary
- Replace floating FunctionCallNotification with inline ToolCallStatus component in chat panel
- Show "Formulating response..." indicator after tools complete to improve UX
- Add missing skeleton loader for Profile bento card on dashboard
- Add Clock icon to Experience line in Profile card for consistency

## Test plan
- [x] Start dev server and open dashboard - verify 6 skeleton loaders appear during loading
- [x] Open chat panel and send a message that triggers tools
- [x] Verify tool status appears inline (not floating in top-right)
- [x] Verify "Formulating response..." shows after tools complete
- [x] Verify Profile card Experience line has Clock icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)