### PR TITLE
Fix chat persistence, update app title, and fix requirements generation

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Databricks GenAI App Template</title>
+    <title>Personal Finance App (Demo)</title>
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/client/src/components/chat/ChatCore.tsx
+++ b/client/src/components/chat/ChatCore.tsx
@@ -130,6 +130,16 @@ export function ChatCore({
     }
   }, [chatId, currentSessionId]);
 
+  // Load chat history on mount if chatId is provided
+  // This handles the case where component remounts with the same chatId
+  useEffect(() => {
+    if (chatId && messages.length === 0 && !isLoading) {
+      devLog("Mount: Loading chat history for:", chatId);
+      loadChatHistory(chatId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     scrollToBottom();

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ uvicorn>=0.34.0
 httpx>=0.28.0
 pydantic>=2.10.0
 requests>=2.32.0
-databricks-sdk>=0.44.1
+databricks-sdk>=0.56.0
 tenacity==9.0.0
 pillow==11.1.0
 websockets==15.0
@@ -19,5 +19,9 @@ protobuf>=3.12.0,<5
 pandas==2.3.0
 flask==3.1.0
 werkzeug==3.1.3
-openai>=1.0.0
+sqlalchemy[asyncio]>=2.0.41
+alembic>=1.16.1
+asyncpg>=0.30.0
+greenlet>=3.0.0
+psycopg2-binary>=2.9.11
 databricks-sql-connector>=3.0.0

--- a/scripts/generate_server_requirements.py
+++ b/scripts/generate_server_requirements.py
@@ -57,9 +57,6 @@ def generate_server_requirements():
       content = f.read()
     dependencies = parse_dependencies_manual(content)
 
-  # Extract dependencies
-  dependencies = pyproject.get('project', {}).get('dependencies', [])
-
   # Generate requirements.txt content
   requirements_content = [
     '# Auto-generated from pyproject.toml with semantic versioning ranges',


### PR DESCRIPTION
## Summary
- Change browser tab title from "Databricks GenAI App Template" to "Personal Finance App (Demo)"
- Fix chat messages resetting on navigation by adding mount effect to reload chat history when component remounts with same chatId
- Fix bug in generate_server_requirements.py where duplicate line caused NameError in fallback code path
- Regenerate requirements.txt with missing dependencies (sqlalchemy, alembic, asyncpg, greenlet, psycopg2-binary) and updated versions

## Test plan
- [x] Verify browser tab shows "Personal Finance App (Demo)"
- [x] Send chat message, navigate away, navigate back - messages should persist
- [x] Run `python scripts/generate_server_requirements.py` to verify script works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)